### PR TITLE
bitbake-setup: Fix path to shell

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -106,9 +106,9 @@ def setup_build(config, layerdir, builddir):
     build_script = os.path.join(builddir, "build.sh")
     init_script = os.path.join(builddir, "init-build-env")
     targets = " && ".join(config["targets"])
-    shell = os.environ["SHELL"]
+    shell = os.path.basename(os.environ.get("SHELL","bash"))
     with open(build_script,'w') as f:
-        f.write("#!{}\n. {} && {}\n".format(shell, init_script, targets))
+        f.write("#!/usr/bin/env {}\n. {} && {}\n".format(shell, init_script, targets))
     st = os.stat(build_script)
     os.chmod(build_script, st.st_mode | stat.S_IEXEC)
     print("\nRun {} to build using this configuration.".format(build_script))


### PR DESCRIPTION
Use an alternate method to fetch the value of SHELL with a default value in the case of SHELL not being set.  Also, change the interpreter in the build.sh to "/usr/bin/env $SHELL" so that whatever the value of SHELL gets expanded to can correctly start the script.