### PR TITLE
Avoid failing when git user details are not configured

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -539,7 +539,7 @@ def install_buildtools(settings, args, d):
             print("Buildtools are already installed in {}.".format(buildtools_install_dir))
             env_scripts = glob.glob(os.path.join(buildtools_install_dir, 'environment-setup-*'))
             if env_scripts:
-                print("If you wish to use them, you need to source the the environment setup script e.g.")
+                print("If you wish to use them, you need to source the environment setup script e.g.")
                 for s in env_scripts:
                     print("$ . {}".format(s))
             print("You can also re-run bitbake-setup install-buildtools with --force option to force a reinstallation.")

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -368,7 +368,7 @@ def init_config(settings, args, d):
 
     source_overrides = json.load(open(args.source_overrides)) if args.source_overrides else {'sources':{}}
     upstream_config = obtain_config(settings, args, source_overrides, d)
-    print("\nRun 'bitbake-setup --non-interactive init {}' to select this configuration non-interactively.\n".format(upstream_config['non-interactive-cmdline-options']))
+    print("\nRun 'bitbake-setup init --non-interactive {}' to select this configuration non-interactively.\n".format(upstream_config['non-interactive-cmdline-options']))
 
     builddir = os.path.join(os.path.abspath(args.top_dir), upstream_config['non-interactive-cmdline-options'].replace(" ","-").replace("/","_"))
     if os.path.exists(builddir):

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -392,6 +392,9 @@ def init_config(settings, args, d):
     os.makedirs(layerdir)
 
     bb.process.run("git -C {} init -b main".format(confdir))
+    # Make sure commiting doesn't fail if no default git user is configured on the machine
+    bb.process.run("git -C {} config user.name bitbake-setup".format(confdir))
+    bb.process.run("git -C {} config user.email bitbake-setup@not.set".format(confdir))
     bb.process.run("git -C {} commit --allow-empty -m 'Initial commit'".format(confdir))
 
     bb.event.register("bb.build.TaskProgress", handle_task_progress, data=d)


### PR DESCRIPTION
In case a git username and email are not configured, then git errors
out when committing the initial and later the changed configuration
of the setup. This can happen if bitbake-setup is running in a
container, or for example if the user just doesn't use git for
committing.

To allow the script to still finish, verify upon start if the user
has the necessary details (name and email) configured in git. If not,
then use dummy details for committing.

Unfortunately `--author=Bitbake Setup <noreply@yoctoproject.org>` 
git argument isn't sufficient, git seems to require `user.name` and
 `user.email` configuration items specifically.

Once I fixed it at the first place, it also failed at a second one, so rather 
changed all git commands.