### PR TITLE
bitbake-setup: bblayers formating fix; config_name with version numbers; top-dir for subcommands;  and shell environment exports for init-build-env

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -179,7 +179,7 @@ def setup_bitbake_build(bitbake_config, layerdir, builddir):
     if os.path.exists(bitbake_confdir):
         os.rename(bitbake_confdir, backup_bitbake_confdir)
 
-    if layers:
+    if layers and not template:
         _setup_build_conf(layers, bitbake_confdir)
 
     if template:

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -109,7 +109,7 @@ def setup_bitbake_build(bitbake_config, layerdir, builddir):
     def _setup_build_conf(layers, build_conf_dir):
         os.makedirs(build_conf_dir)
         layers_s = "\n".join(["  {} \\".format(os.path.join(layerdir,l)) for l in layers])
-        bblayers_conf = """BBLAYERS ?= " \
+        bblayers_conf = """BBLAYERS ?= " \\
 {}
   "
 """.format(layers_s)

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -143,9 +143,23 @@ def setup_bitbake_build(bitbake_config, layerdir, builddir):
             f.write("")
 
     def _make_init_build_env(builddir, initbuildenv):
+        exports = []
+        env = bitbake_config.get("build-environment")
+        if env:
+            for key, value in env.items():
+                if isinstance(value, list):
+                    joined = " \\\n".join(value)
+                    value = joined
+                value = value.replace("##BUILDDIR##", builddir)
+                exports.append(f'export {key}="{value}"')
+
         cmd = ". {} {}".format(initbuildenv, builddir)
         initbuild_in_builddir = os.path.join(builddir, 'init-build-env')
+
         with open(initbuild_in_builddir, 'w') as f:
+            f.write("# init-build-env wrapper created by bitbake-setup\n")
+            for e in exports:
+                f.write(e + '\n')
             f.write(cmd)
 
     bitbake_builddir = os.path.join(builddir, "build")

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -741,10 +741,12 @@ def main():
     parser_init.set_defaults(func=init_config)
 
     parser_status = subparsers.add_parser('status', help='Check if the build needs to be synchronized with configuration')
+    add_top_dir_arg(parser_status)
     add_build_dir_arg(parser_status)
     parser_status.set_defaults(func=build_status)
 
     parser_update = subparsers.add_parser('update', help='Update a build to be in sync with configuration')
+    add_top_dir_arg(parser_update)
     add_build_dir_arg(parser_update)
     parser_update.set_defaults(func=build_update)
 

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -50,7 +50,13 @@ def save_bb_cache():
     bb.fetch2.fetcher_parse_done()
 
 def get_config_name(config):
-    return os.path.basename(config).split('.')[0]
+    from pathlib import Path
+
+    known_suffixes = ['.json', '.conf', '.override']
+    path = Path(config)
+    while path.suffix in known_suffixes:
+        path = path.with_suffix('')
+    return path.name
 
 def write_config(config, config_dir):
     with open(os.path.join(config_dir, "config-upstream.json"),'w') as s:


### PR DESCRIPTION
bitbake-setup: one fix, two improvements and one suggestion

While further exploring the new way to setup yocto builds from a singular configuration.json (e.g. not backed by a registry... yet) i've come across these four things:
1. 22046840 the generated bblayers.conf was "asymetric"
2. 214b7ebc version numbers in the configuration filename where picked up as extensions
3. 2a02ab02 the --top-dir didn't apply to the other sub-commands (intentionally?)
4. a9020f7f there is/was no way to pre-configure environment variables (e.g. BB_ENV_PASSTHROUGH and others) - background: our current CI-build-setup involves setup-layers plus a custom build-env script; since bitbake-setup wraps the oe-init-build-env-init already/once more... this could be a nice(r) one-stop solution

Feel free to cherry-pick, squash or discard any of the commits;
if you'd rather have separate PRs or the commit(s) pushed to the mailing-list - just say so :-)