### PR TITLE
bitbake-setup: strip away known extensions to get config_name

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -50,7 +50,13 @@ def save_bb_cache():
     bb.fetch2.fetcher_parse_done()
 
 def get_config_name(config):
-    return os.path.basename(config).split('.')[0]
+    from pathlib import Path
+
+    known_suffixes = ['.json', '.conf', '.override']
+    path = Path(config)
+    while path.suffix in known_suffixes:
+        path = path.with_suffix('')
+    return path.name
 
 def write_config(config, config_dir):
     with open(os.path.join(config_dir, "config-upstream.json"),'w') as s:


### PR DESCRIPTION
Strip away a list of known extensions to get to the config (base) name by making use of pahtlib features for suffix handling.

With this change configuration names with version numbers in the filename would now also be possible.
Similar to how yocto recipes are versiones: `name_1.2.3.bb`

Example (with a config that uses only templates, and no fragments):
```
$/tmp/bitbake-setup> ./bitbake/bin/bitbake-setup  --global-settings /tmp/bitbake-setup/.conf init --top-dir-prefix /tmp/bitbake-setup --top-dir-name gs geosurv_5.0.17.conf.json 
Loading global settings from
    /tmp/bitbake-setup/.conf
<snip>
Reading configuration from local file
    geosurv_5.0.17.conf.json

Selecting the only available bitbake configuration geosurv

Run 'bitbake-setup init --non-interactive geosurv_5.0.17.conf.json geosurv' to select this configuration non-interactively.
<snip>
Setting up bitbake configuration in
    /tmp/bitbake-setup/gs/geosurv_5.0.17-geosurv/build
<snip>
The bitbake configuration files (local.conf, bblayers.conf and more) can be found in
    /tmp/bitbake-setup/gs/geosurv_5.0.17-geosurv/build/conf

To run builds, source the environment using
    source /tmp/bitbake-setup/gs/geosurv_5.0.17-geosurv/build/init-build-env
```

before this change, bitbake-setup would only leave `geosurv_5` as the config name, leading to a different/"unpredictable" build directory name :-S