### PR TITLE
bitbake-setup: support exporting shell environment variables via init-build-env

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -162,8 +162,31 @@ def setup_bitbake_build(bitbake_config, layerdir, builddir, thisdir):
         builddir = os.path.realpath(builddir)
         cmd = "cd {}\nset {}\n. ./oe-init-build-env\n".format(oeinitbuildenvdir, builddir)
         initbuild_in_builddir = os.path.join(builddir, 'init-build-env')
+
         with open(initbuild_in_builddir, 'w') as f:
-            f.write(cmd)
+            f.write("# init-build-env wrapper created by bitbake-setup\n")
+            f.write(cmd + '\n')
+
+    def _prepend_passthrough_to_init_build_env(builddir):
+        env = bitbake_config.get("bb-env-passthrough-additions")
+        if not env:
+            return
+
+        initbuild_in_builddir = os.path.join(builddir, 'init-build-env')
+        with open(initbuild_in_builddir) as f:
+            content = f.read()
+
+        joined = " \\\n".join(env)
+        env = "export BB_ENV_PASSTHROUGH_ADDITIONS=\" \\\n"
+        env += "${BB_ENV_PASSTHROUGH_ADDITIONS} \\\n"
+        env += joined
+        env += '"'
+
+        with open(initbuild_in_builddir, 'w') as f:
+            f.write("# environment passthrough added by bitbake-setup\n")
+            f.write(env + '\n')
+            f.write('\n')
+            f.write(content)
 
     bitbake_builddir = os.path.join(builddir, "build")
     print("Setting up bitbake configuration in\n    {}\n".format(bitbake_builddir))
@@ -193,6 +216,8 @@ def setup_bitbake_build(bitbake_config, layerdir, builddir, thisdir):
             print("Could not find oe-init-build-env in any of the layers; please use another mechanism to initialize the bitbake environment")
             return
         _make_init_build_env(bitbake_builddir, os.path.realpath(oeinitbuildenvdir))
+
+    _prepend_passthrough_to_init_build_env(bitbake_builddir)
 
     siteconf_symlink = os.path.join(bitbake_confdir, "site.conf")
     siteconf = os.path.normpath(os.path.join(builddir, '..', "site.conf"))


### PR DESCRIPTION
Rebased version of #7 

This patch adds support for exporting shell environment variables from the `init-build-env` wrapper script generated by `bitbake-setup`, based on per-configuration JSON settings.

This enables CI workflows to inject environment-specific data - such as build number, host, build type, or credentials required to fetch from certain SRC_URIs - which cannot be captured via configuration fragments alone. These variables are now handled early in the setup process and exported directly into the build environment.

**Especially tracking BB_ENV_PASSTHROUGH(_ADDITIONS) this way is interesting, since this is (currently) not possible with bitbake configuration (or fragments).**

Example:
```
  "build-environment": {
      "KEY": "value",
      "MULTILINE": [
          "line1",
          "line2"
      ]
      "ACME_DIR": "##BUILDDIR##/../layers/meta-acme",
      "BB_ENV_PASSTHROUGH_ADDITIONS": [
          "$BB_ENV_PASSTHROUGH_ADDITIONS",
          "ACME_DIR",
          "ARTIFACTORY_TOKEN",
          "ARTIFACTORY_USERNAME",
          "GITHUB_TOKEN",
          "GITHUB_PROTOCOL",
          "KEY",
          "MULTILINE"
          ]
   <snip>
```
the resulting 'init-build-env' would then be:
```
  # init-build-env wrapper created by bitbake-setup
  export KEY="value"
  export MULTILINE="line2 \
  line2"
  export ACME_DIR="/tmp/acme_master-acme-distro_acme-machine_bang/build/../layers/meta-acme"
  export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS \
  ACME_DIR \
  ARTIFACTORY_TOKEN \
  ARTIFACTORY_USERNAME \
  GITHUB_TOKEN \
  GITHUB_PROTOCOL \
  KEY \
  MULTILINE"
  . /tmp/acme_master-acme-distro_acme-machine_bang/layers/openembedded-core/oe-init-build-env /tmp/bitbake-setup/gs/acme_master-acme-distro_acme-machine_bang/build
```