### PR TITLE
bitbake-setup: add 'metavar' for self-descriptive parameters

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -751,8 +751,10 @@ def main():
     parser.add_argument('-q', '--quiet', help='Print only errors', action='store_true')
     parser.add_argument('--color', choices=['auto', 'always', 'never'], default='auto', help='Colorize output (where %(metavar)s is %(choices)s)', metavar='COLOR')
     parser.add_argument('--no-network', action='store_true', help='Do not check whether configuration repositories and layer repositories have been updated; use only the local cache.')
-    parser.add_argument('--global-settings', action='store', help='Path to the global settings file.')
-    parser.add_argument('--setting', default=[], action='append', nargs=3, help='Modify a setting (for this bitbake-setup invocation only), for example "--setting default top-dir-prefix /path/to/top/dir".')
+    parser.add_argument('--global-settings', action='store', metavar='PATH', help='Path to the global settings file.')
+    parser.add_argument('--setting', default=[], action='append',
+                        nargs=3, metavar=('SECTION', 'KEY', 'VALUE'),
+                        help='Modify a setting (for this bitbake-setup invocation only), for example "--setting default top-dir-prefix /path/to/top/dir".')
 
     subparsers = parser.add_subparsers()
 


### PR DESCRIPTION
Add a metavar to the argparse options to have a self-descriptive help text. Otherwise argpase defaults to use the argument name in all-uppercase.
```
# Before:
usage: bitbake-setup [-h] [-d] [-q] [--color COLOR] [--no-network] [--global-settings GLOBAL_SETTINGS] [--setting SETTING SETTING SETTING]
                     {list,init,status,update,install-buildtools,settings} ...

# After:
usage: bitbake-setup [-h] [-d] [-q] [--color COLOR] [--no-network] [--global-settings PATH] [--setting SECTION KEY VALUE]
                     {list,init,status,update,install-buildtools,settings} ...
```