### PR TITLE
bitbake-setup: init: suggest removing a partially initialized top-dir

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -443,7 +443,7 @@ def init_config(top_dir, settings, args, d):
 
     builddir = os.path.join(os.path.abspath(top_dir), args.build_dir_name or "{}-{}".format(upstream_config['name']," ".join(upstream_config['non-interactive-cmdline-options'][1:]).replace(" ","-").replace("/","_")))
     if os.path.exists(os.path.join(builddir, "layers")):
-        print("Build already initialized in {}\nUse 'bitbake-setup status' to check if it needs to be updated or 'bitbake-setup update' to perform the update.".format(builddir))
+        print(f"Build already initialized in:\n    {builddir}\nUse 'bitbake-setup status' to check if it needs to be updated, or 'bitbake-setup update' to perform the update.\nIf you would like to start over and re-initialize a build in this directory, remove it, and run 'bitbake-setup init' again.")
         return
 
     print("Initializing a build in\n    {}".format(builddir))


### PR DESCRIPTION
In cases where the first call to 'init' failed or was aborted before creating the 'build/init-build-env' has been created, a user can get stuck: a second call to init aborts, suggesting 'status' or 'update' but these to refuse because the --build-dir is not valid.

Guide the user by adding a suggestion to start over from scratch.