### PR TITLE
bitbake-setup: sub operations for `settings`

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -751,8 +751,9 @@ def main():
     parser.add_argument('-q', '--quiet', help='Print only errors', action='store_true')
     parser.add_argument('--color', choices=['auto', 'always', 'never'], default='auto', help='Colorize output (where %(metavar)s is %(choices)s)', metavar='COLOR')
     parser.add_argument('--no-network', action='store_true', help='Do not check whether configuration repositories and layer repositories have been updated; use only the local cache.')
-    parser.add_argument('--global-settings', action='store', help='Path to the global settings file.')
-    parser.add_argument('--setting', default=[], dest='cmdline_settings', action='append', nargs=3,
+    parser.add_argument('--global-settings', action='store', metavar='PATH', help='Path to the global settings file.')
+    parser.add_argument('--setting', default=[], action='append', dest='cmdline_settings',
+                        nargs=3, metavar=('SECTION', 'SETTING', 'VALUE'),
                         help='Modify a setting (for this bitbake-setup invocation only), for example "--setting default top-dir-prefix /path/to/top/dir".')
 
     subparsers = parser.add_subparsers()

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -752,7 +752,8 @@ def main():
     parser.add_argument('--color', choices=['auto', 'always', 'never'], default='auto', help='Colorize output (where %(metavar)s is %(choices)s)', metavar='COLOR')
     parser.add_argument('--no-network', action='store_true', help='Do not check whether configuration repositories and layer repositories have been updated; use only the local cache.')
     parser.add_argument('--global-settings', action='store', help='Path to the global settings file.')
-    parser.add_argument('--setting', default=[], action='append', nargs=3, help='Modify a setting (for this bitbake-setup invocation only), for example "--setting default top-dir-prefix /path/to/top/dir".')
+    parser.add_argument('--setting', default=[], dest='cmdline_settings', action='append', nargs=3,
+                        help='Modify a setting (for this bitbake-setup invocation only), for example "--setting default top-dir-prefix /path/to/top/dir".')
 
     subparsers = parser.add_subparsers()
 
@@ -822,13 +823,13 @@ def main():
                          }
 
         global_settings = load_settings(global_settings_path(args))
-        top_dir = get_top_dir(args, merge_settings(builtin_settings, global_settings, {}, args.setting))
+        top_dir = get_top_dir(args, merge_settings(builtin_settings, global_settings, {}, args.cmdline_settings))
 
         # This cannot be set with the rest of the builtin settings as top_dir needs to be determined first
         builtin_settings['default']['dl-dir'] = os.path.join(top_dir, '.bitbake-setup-downloads')
 
         topdir_settings = load_settings(default_settings_path(top_dir))
-        all_settings = merge_settings(builtin_settings, global_settings, topdir_settings, args.setting)
+        all_settings = merge_settings(builtin_settings, global_settings, topdir_settings, args.cmdline_settings)
 
         if args.func == settings_func:
             settings_func(top_dir, all_settings, args)

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -670,22 +670,20 @@ def change_setting(top_dir, args):
         settings_path = default_settings_path(top_dir)
     settings = load_settings(settings_path)
 
-    if args.section and args.key and args.value:
+    if args.subcommand == 'set':
         if args.section not in settings.keys():
             settings[args.section] = {}
-        settings[args.section][args.key] = args.value
-        print("Setting '{}' in section '{}' is changed to '{}'".format(args.key, args.section, args.value))
-    if args.unset:
-        section = args.unset[0]
-        setting = args.unset[1]
-        if section in settings.keys() and setting in settings[section].keys():
-            del settings[section][setting]
-            print("Setting '{} in section '{}' is removed".format(setting, section))
+        settings[args.section][args.setting] = args.value
+        print(f"From section '{args.section}' the setting '{args.setting}' was changed to '{args.value}'")
+    if args.subcommand == 'unset':
+        if args.section in settings.keys() and args.setting in settings[args.section].keys():
+            del settings[args.section][args.setting]
+            print(f"From section '{args.section}' the setting '{args.setting}' has been removed")
 
     os.makedirs(os.path.dirname(settings_path), exist_ok=True)
     with open(settings_path, 'w') as settingsfile:
         settings.write(settingsfile)
-    print("New settings written to {}".format(settings_path))
+    print(f"Settings written to {settings_path}")
 
 def list_settings(all_settings):
     for section, section_settings in all_settings.items():
@@ -693,9 +691,9 @@ def list_settings(all_settings):
             print("{} {} {}".format(section, key, value))
 
 def settings_func(top_dir, all_settings, args):
-    if args.list:
+    if args.subcommand == 'list':
         list_settings(all_settings)
-    else:
+    elif args.subcommand == 'set' or args.subcommand == 'unset':
         change_setting(top_dir, args)
 
 def get_build_dir_via_bbpath():
@@ -784,14 +782,28 @@ def main():
     parser_install_buildtools.add_argument('--force', action='store_true', help='Force a reinstall of buildtools over the previous installation.')
     parser_install_buildtools.set_defaults(func=install_buildtools)
 
-    parser_settings = subparsers.add_parser('settings', help='List current settings, or set or unset a setting in a settings file (e.g. the default prefix and name of the top directory, the location of build configuration registry, downloads directory and other settings specific to a top directory)')
-    parser_settings.add_argument('section', nargs='?', help="Section in a settings file, typically 'default'")
-    parser_settings.add_argument('key', nargs='?', help="Name of the setting")
-    parser_settings.add_argument('value', nargs='?', help="Value of the setting")
-    parser_settings.add_argument('--global', action='store_true', help="Modify the setting in a global settings file, rather than one specific to a top directory")
-    parser_settings.add_argument('--unset', nargs=2, help="Unset a setting, e.g. 'bitbake-setup settings --unset default registry' would revert to the registry setting in a global settings file")
-    parser_settings.add_argument('-l' ,'--list', action='store_true', help="List all settings with their values")
+    parser_settings_arg_global = argparse.ArgumentParser(add_help=False)
+    parser_settings_arg_global.add_argument('--global', action='store_true', help="Modify the setting in a global settings file, rather than one specific to a top directory")
+
+    parser_settings = subparsers.add_parser('settings', parents=[parser_settings_arg_global],
+                                            help='List current settings, or set or unset a setting in a settings file (e.g. the default prefix and name of the top directory, the location of build configuration registry, downloads directory and other settings specific to a top directory)')
     parser_settings.set_defaults(func=settings_func)
+
+    subparser_settings = parser_settings.add_subparsers(dest="subcommand", required=True, help="The action to perform on the settings file")
+
+    parser_settings_list = subparser_settings.add_parser('list',
+                                                         help="List all settings with their values")
+
+    parser_settings_set = subparser_settings.add_parser('set', parents=[parser_settings_arg_global],
+                                                        help="In a Section, set a setting to a certain value")
+    parser_settings_set.add_argument("section", metavar="<section>", help="Section in a settings file, typically 'default'")
+    parser_settings_set.add_argument("setting", metavar="<setting>", help="Name of a setting")
+    parser_settings_set.add_argument("value", metavar="<value>", help="The setting value")
+
+    parser_settings_unset = subparser_settings.add_parser('unset', parents=[parser_settings_arg_global],
+                                                          help="Unset a setting, e.g. 'bitbake-setup settings unset default registry' would revert to the registry setting in a global settings file")
+    parser_settings_unset.add_argument("section", metavar="<section>", help="Section in a settings file, typically 'default'")
+    parser_settings_unset.add_argument("setting", metavar="<setting>", help="The setting to remove")
 
     args = parser.parse_args()
 

--- a/lib/bb/tests/setup.py
+++ b/lib/bb/tests/setup.py
@@ -232,25 +232,25 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
         self.runbbsetup("--help")
 
         # set up global location for top-dir-prefix
-        out = self.runbbsetup("settings --global default top-dir-prefix {}".format(self.tempdir))
+        out = self.runbbsetup("settings set --global default top-dir-prefix {}".format(self.tempdir))
         settings_path = "{}/global-config".format(self.tempdir)
         self.assertIn(settings_path, out[0])
-        self.assertIn("Setting 'top-dir-prefix' in section 'default' is changed to", out[0])
-        self.assertIn("New settings written to".format(settings_path), out[0])
-        out = self.runbbsetup("settings --global default dl-dir {}".format(os.path.join(self.tempdir, 'downloads')))
-        self.assertIn("Setting 'dl-dir' in section 'default' is changed to", out[0])
-        self.assertIn("New settings written to".format(settings_path), out[0])
+        self.assertIn("From section 'default' the setting 'top-dir-prefix' was changed to", out[0])
+        self.assertIn("Settings written to".format(settings_path), out[0])
+        out = self.runbbsetup("settings set --global default dl-dir {}".format(os.path.join(self.tempdir, 'downloads')))
+        self.assertIn("From section 'default' the setting 'dl-dir' was changed to", out[0])
+        self.assertIn("Settings written to".format(settings_path), out[0])
 
         # check that writing settings works and then adjust them to point to
         # test registry repo
-        out = self.runbbsetup("settings default registry 'git://{};protocol=file;branch=master;rev=master'".format(self.registrypath))
+        out = self.runbbsetup("settings set default registry 'git://{};protocol=file;branch=master;rev=master'".format(self.registrypath))
         settings_path = "{}/bitbake-builds/settings.conf".format(self.tempdir)
         self.assertIn(settings_path, out[0])
-        self.assertIn("Setting 'registry' in section 'default' is changed to", out[0])
-        self.assertIn("New settings written to".format(settings_path), out[0])
+        self.assertIn("From section 'default' the setting 'registry' was changed to", out[0])
+        self.assertIn("Settings written to".format(settings_path), out[0])
 
         # check that listing settings works
-        out = self.runbbsetup("settings --list")
+        out = self.runbbsetup("settings list")
         self.assertIn("default top-dir-prefix {}".format(self.tempdir), out[0])
         self.assertIn("default dl-dir {}".format(os.path.join(self.tempdir, 'downloads')), out[0])
         self.assertIn("default registry {}".format('git://{};protocol=file;branch=master;rev=master'.format(self.registrypath)), out[0])


### PR DESCRIPTION
Previously the sub-command 'settings' would take any number of
arguments and then silently do nothing if the number wasn't three.

The help text was also not clear about this, marking the positionals
separately as optional:

`usage: bitbake-setup settings [-h] [--global] [--unset UNSET UNSET] [-l] [section] [key] [value]`

The '--unset SECTION SETTING' also did not  integrate too well, as it had its own positional arguments for section+setting.

For a bit more consistency and a explorable help, a sub-subparser is added, that provides the commands:
```
  bitbake-setup settings list
  bitbake-setup settings set foo bar baz
  bitbake-setup settings unset foo bar
```
with a '--global' that is added from a stand-alone parent parser, so
that it shows up in all sub-command help texts.

The new help text now reads:
`usage: bitbake-setup settings [-h] [--global] {list,set,unset} ...`

and the respective sub commands:
```
usage: bitbake-setup settings list [-h] [--global]
usage: bitbake-setup settings set [-h] [--global] <section> <setting> <value>
usage: bitbake-setup settings unset [-h] [--global] <section> <setting>
```
