### PR TITLE
capture sources-state.json during checkout_layers

### DIFF
--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -18,6 +18,7 @@ import configparser
 import datetime
 import glob
 import subprocess
+import copy
 
 default_registry = os.path.normpath(os.path.dirname(__file__) + "/../default-registry")
 
@@ -61,6 +62,12 @@ def write_upstream_config(config_dir, config_data):
     with open(os.path.join(config_dir, "config-upstream.json"),'w') as s:
         json.dump(config_data, s, sort_keys=True, indent=4)
 
+def write_sources_fixed_revisions(config_dir, config_data):
+    sources = {}
+    sources['sources'] = config_data
+    with open(os.path.join(config_dir, "sources-fixed-revisions.json"),'w') as s:
+        json.dump(sources, s, sort_keys=True, indent=4)
+
 def commit_config(config_dir):
     bb.process.run("git -C {} add .".format(config_dir))
     bb.process.run("git -C {} commit --no-verify -a -m 'Configuration at {}'".format(config_dir, time.asctime()))
@@ -76,6 +83,7 @@ def _write_layer_list(dest, repodirs):
         json.dump({"version":"1.0","layers":layers}, f, sort_keys=True, indent=4)
 
 def checkout_layers(layers, layerdir, d):
+    layers_fixed_revisions = copy.deepcopy(layers)
     repodirs = []
     oesetupbuild = None
     print("Fetching layer/tool repositories into {}".format(layerdir))
@@ -99,6 +107,9 @@ def checkout_layers(layers, layerdir, d):
                 src_uri = f"{fetchuri};protocol={prot};rev={rev};nobranch=1;destsuffix={repodir}"
             fetcher = bb.fetch.Fetch([src_uri], d)
             do_fetch(fetcher, layerdir)
+            urldata = fetcher.ud[src_uri]
+            revision = urldata.revision
+            layers_fixed_revisions[r_name]['git-remote']['rev'] = revision
 
         if os.path.exists(os.path.join(layerdir, repodir, 'scripts/oe-setup-build')):
             oesetupbuild = os.path.join(layerdir, repodir, 'scripts/oe-setup-build')
@@ -114,6 +125,8 @@ def checkout_layers(layers, layerdir, d):
             if os.path.lexists(symlink):
                 os.remove(symlink)
             os.symlink(os.path.relpath(t,layerdir),symlink)
+
+    return layers_fixed_revisions
 
 def setup_bitbake_build(bitbake_config, layerdir, setupdir, thisdir):
     def _setup_build_conf(layers, build_conf_dir):
@@ -269,15 +282,16 @@ def get_registry_config(registry_path, id):
     raise Exception("Unable to find {} in available configurations; use 'list' sub-command to see what is available".format(id))
 
 def update_build(config, confdir, setupdir, layerdir, d):
-    layer_config = config["data"]["sources"]
+    layer_config = copy.deepcopy(config["data"]["sources"])
     layer_overrides = config["source-overrides"]["sources"]
     for k,v in layer_overrides.items():
         if k in layer_config:
             layer_config[k]["git-remote"] = v["git-remote"]
-    checkout_layers(layer_config, layerdir, d)
+    sources_fixed_revisions = checkout_layers(layer_config, layerdir, d)
     bitbake_config = config["bitbake-config"]
     thisdir = os.path.dirname(config["path"]) if config["type"] == 'local' else None
     setup_bitbake_build(bitbake_config, layerdir, setupdir, thisdir)
+    write_sources_fixed_revisions(confdir, sources_fixed_revisions)
 
 def int_input(allowed_values):
     n = None
@@ -471,8 +485,8 @@ def init_config(top_dir, settings, args, d):
     bb.event.register("bb.build.TaskProgress", handle_task_progress, data=d)
 
     write_upstream_config(confdir, upstream_config)
-    commit_config(confdir)
     update_build(upstream_config, confdir, setupdir, layerdir, d)
+    commit_config(confdir)
 
     bb.event.remove("bb.build.TaskProgress", None)
 

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -57,9 +57,9 @@ def get_config_name(config):
     else:
         raise Exception("Config file {} does not end with {}, please rename the file.".format(config, suffix))
 
-def write_config(config, config_dir):
+def write_upstream_config(config_dir, config_data):
     with open(os.path.join(config_dir, "config-upstream.json"),'w') as s:
-        json.dump(config, s, sort_keys=True, indent=4)
+        json.dump(config_data, s, sort_keys=True, indent=4)
 
 def commit_config(config_dir):
     bb.process.run("git -C {} add .".format(config_dir))
@@ -469,7 +469,7 @@ def init_config(top_dir, settings, args, d):
 
     bb.event.register("bb.build.TaskProgress", handle_task_progress, data=d)
 
-    write_config(upstream_config, confdir)
+    write_upstream_config(confdir, upstream_config)
     commit_config(confdir)
     update_build(upstream_config, confdir, setupdir, layerdir, d)
 
@@ -526,7 +526,7 @@ def build_status(top_dir, settings, args, d, update=False):
     source_overrides = current_upstream_config["source-overrides"]
     new_upstream_config = obtain_config(top_dir, settings, args, source_overrides, d)
 
-    write_config(new_upstream_config, confdir)
+    write_upstream_config(confdir, new_upstream_config)
     config_diff = bb.process.run('git -C {} diff'.format(confdir))[0]
 
     if config_diff:

--- a/bin/bitbake-setup
+++ b/bin/bitbake-setup
@@ -90,13 +90,14 @@ def checkout_layers(layers, layerdir, d):
         remotes = r_remote['remotes']
 
         for remote in remotes:
-            type,host,path,user,pswd,params = bb.fetch.decodeurl(remotes[remote]["uri"])
+            prot,host,path,user,pswd,params = bb.fetch.decodeurl(remotes[remote]["uri"])
             fetchuri = bb.fetch.encodeurl(('git',host,path,user,pswd,params))
             print("    {}".format(r_name))
             if branch:
-                fetcher = bb.fetch.Fetch(["{};protocol={};rev={};branch={};destsuffix={}".format(fetchuri,type,rev,branch,repodir)], d)
+                src_uri = f"{fetchuri};protocol={prot};rev={rev};branch={branch};destsuffix={repodir}"
             else:
-                fetcher = bb.fetch.Fetch(["{};protocol={};rev={};nobranch=1;destsuffix={}".format(fetchuri,type,rev,repodir)], d)
+                src_uri = f"{fetchuri};protocol={prot};rev={rev};nobranch=1;destsuffix={repodir}"
+            fetcher = bb.fetch.Fetch([src_uri], d)
             do_fetch(fetcher, layerdir)
 
         if os.path.exists(os.path.join(layerdir, repodir, 'scripts/oe-setup-build')):

--- a/lib/bb/tests/setup.py
+++ b/lib/bb/tests/setup.py
@@ -187,6 +187,12 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
         bb_conf_path = os.path.join(bb_build_path, 'conf')
         self.assertTrue(os.path.exists(os.path.join(bb_build_path, 'init-build-env')))
 
+        with open(os.path.join(setuppath, 'config', "sources-fixed-revisions.json")) as f:
+            sources_fixed_revisions = json.load(f)
+        self.assertTrue('test-repo' in sources_fixed_revisions['sources'].keys())
+        revision = self.git('rev-parse HEAD', cwd=self.testrepopath).strip()
+        self.assertEqual(revision, sources_fixed_revisions['sources']['test-repo']['git-remote']['rev'])
+
         if "oe-template" in bitbake_config:
             with open(os.path.join(bb_conf_path, 'conf-summary.txt')) as f:
                 self.assertEqual(f.read(), bitbake_config["oe-template"])

--- a/lib/bb/tests/setup.py
+++ b/lib/bb/tests/setup.py
@@ -177,10 +177,12 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
         self.git('add {}'.format(name), cwd=self.testrepopath)
         self.git('commit -m "Adding {}"'.format(name), cwd=self.testrepopath)
 
-    def check_setupdir_files(self, setuppath, test_file_content, json_config):
+    def check_setupdir_files(self, setuppath, test_file_content):
+        with open(os.path.join(setuppath, 'config', "config-upstream.json")) as f:
+            config_upstream = json.load(f)
         with open(os.path.join(setuppath, 'layers', 'test-repo', 'test-file')) as f:
             self.assertEqual(f.read(), test_file_content)
-        bitbake_config = json_config["bitbake-config"]
+        bitbake_config = config_upstream["bitbake-config"]
         bb_build_path = os.path.join(setuppath, 'build')
         bb_conf_path = os.path.join(bb_build_path, 'conf')
         self.assertTrue(os.path.exists(os.path.join(bb_build_path, 'init-build-env')))
@@ -198,7 +200,7 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
                 for l in bitbake_config["bb-layers"]:
                     if l.startswith('{THISDIR}/'):
                         thisdir_layer = os.path.join(
-                            os.path.dirname(json_config["path"]),
+                            os.path.dirname(config_upstream["path"]),
                             l.removeprefix("{THISDIR}/"),
                         )
                         self.assertIn(thisdir_layer, bblayers)
@@ -296,9 +298,7 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
             for c in v['buildconfigs']:
                 out = self.runbbsetup("init --non-interactive {} {}".format(v['cmdline'], c))
                 setuppath = os.path.join(self.tempdir, 'bitbake-builds', '{}-{}'.format(cf, c))
-                with open(os.path.join(setuppath, 'config', "config-upstream.json")) as f:
-                    config_upstream = json.load(f)
-                self.check_setupdir_files(setuppath, test_file_content, config_upstream)
+                self.check_setupdir_files(setuppath, test_file_content)
                 os.environ['BBPATH'] = os.path.join(setuppath, 'build')
                 out = self.runbbsetup("status")
                 self.assertIn("Configuration in {} has not changed".format(setuppath), out[0])
@@ -327,9 +327,7 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
             if c in ('gadget', 'gizmo'):
                 self.assertIn("Existing bitbake configuration directory renamed to {}/build/conf-backup.".format(setuppath), out[0])
                 self.assertIn('-{}+{}'.format(prev_test_file_content, test_file_content), out[0])
-            with open(os.path.join(setuppath, 'config', "config-upstream.json")) as f:
-                config_upstream = json.load(f)
-            self.check_setupdir_files(setuppath, test_file_content, config_upstream)
+            self.check_setupdir_files(setuppath, test_file_content)
 
         # make a new branch in the test layer repo, change a file on that branch,
         # make a new commit, update the top level json config to refer to that branch,
@@ -353,6 +351,4 @@ print("BBPATH is {{}}".format(os.environ["BBPATH"]))
             if c in ('gadget', 'gizmo'):
                 self.assertIn("Existing bitbake configuration directory renamed to {}/build/conf-backup.".format(setuppath), out[0])
                 self.assertIn('-{}+{}'.format(prev_test_file_content, test_file_content), out[0])
-            with open(os.path.join(setuppath, 'config', "config-upstream.json")) as f:
-                config_upstream = json.load(f)
-            self.check_setupdir_files(setuppath, test_file_content, config_upstream)
+            self.check_setupdir_files(setuppath, test_file_content)


### PR DESCRIPTION
When using a layers-setup.conf.json that points only to branches or tags, e.g.:
```
    "bitbake-setup": {
<snip>
    "sources": {                                                                                                                            
        "bitbake": {                                                                                                                        
            "git-remote": {                                                                                                                 
                "branch": "2.8",                                                                                                            
                "describe": "",                                                                                                             
                "remotes": {                                                                                                                
                    "upstream": {                                                                                          
                        "uri": "https://github.com/openembedded/bitbake"                                                                
                    }                                                                                                                       
                },                                                                                                                          
                "rev": "2.8"                                                                                                                
            },                                                                                                                              
            "path": "bitbake"                                                                                                               
        }, 
<snip>
```
the actual revision cloned during a `bitbake-setup init` or `bitbake-setup update` is not recorded.

This changeset would extend the `checkout_layers` to return a sources datastructure, that is then put under version-control as `build/config/sources-state.json` - alongside the build/config/upstream-config.json 

The idea is that to reproduce any build, one could use this file, and feed it back into `bitbake-setup init --sources-overrides`

~A future(?) addition could be~ Adding also a new command that takes the upstream-config.json and the sources-state to write out a self-contained/complete layers-setup.conf.json. This file could then be archived in the registry.

~WIP because of some ToDos in the code that could use bitbake expert knowledge ;-)~

----                 
Example usecase/scenario:
```
# a CI is tasked to build a tip-of-master configuration once a day:
./bitbake/bin/bitbake-setup \
    --setting default top-dir-prefix /tmp/builds --setting default top-dir-name nightly \
    init --non-interactive acme_master.conf.json acme distro/acme machine/gizmo 

# then a build is run, its result is checked, tested, etc, etc

# once deemed OK, a snapshot is stored to later reproduce that exact build:
./bitbake/bin/bitbake-setup \
    --setting default top-dir-prefix /tmp/builds --setting default top-dir-name nightly \
    dump  \
    --build-dir /tmp/builds/nightly/acme_master_master-acme-distro_acme-machine_gizmo/ \
    --output registry/nightly/2025-11-01.conf.json
```